### PR TITLE
Add Code Owners for the Repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,12 @@
+####################################################################
+#
+# List of approvers/reviewers for Canso K8s Data Plane Terraform
+#
+####################################################################
+#
+# Learn about CODEOWNERS file format: 
+#  https://help.github.com/en/articles/about-code-owners
+#
+
+# These owners will be the default owners for everything in the repo.
+@Yugen-ai/platform-engineering


### PR DESCRIPTION
Add Code Owners. PR reviews must need a mandatory PR approval from at-least 1 Code Owner.