### PR TITLE
Fix default names & add a caution message on changing cluster name

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,10 @@ public_subnet_ids = [
 vpc_id = "vpc-xxxxxxxxxxxxxxxxx"
 ```
 
+> [!CAUTION]
+> If you change the cluster name, ensure you update the same in the rest of the configs, especially the IRSA roles.
+> For e.g Each IRSA role has a `cluster_service_accounts` variable that uses the cluster name.
+
 ---
 
 ### Step 3 - AWS IRSA Roles

--- a/canso-dataplane-configs/irsa-roles/canso-agent/auto.tfvars
+++ b/canso-dataplane-configs/irsa-roles/canso-agent/auto.tfvars
@@ -29,7 +29,7 @@ role_name   = "devagent-dataplane-irsa-role"
 name_prefix = "devagent-dataplane-irsa-role"
 
 cluster_service_accounts = {
-  "helm-dep-cluster" = ["canso-dataplane:canso-agent"]
+  "canso-dataplane-cluster" = ["canso-dataplane:canso-agent"]
 }
 
 tags = {

--- a/canso-dataplane-configs/irsa-roles/efs-driver/auto.tfvars
+++ b/canso-dataplane-configs/irsa-roles/efs-driver/auto.tfvars
@@ -23,7 +23,7 @@ iam_policy_tags = {
 }
 
 ############################### 
-## IAM Irsa Role
+## IAM IRSA Role
 ###############################
 
 create_role = true

--- a/canso-dataplane-configs/irsa-roles/spark/auto.tfvars
+++ b/canso-dataplane-configs/irsa-roles/spark/auto.tfvars
@@ -32,8 +32,9 @@ name_prefix = "canso-dataplane-spark-s3-irsa-role"
 cluster_service_accounts = {
   "canso-dataplane-cluster" = ["spark-streaming-jobs:spark-operator-spark", "spark-streaming-ml-jobs:spark-operator-spark"]
   # TODO - Question re `spark-operator-spark` - To be resolved before PR merge.
-  # https://github.com/Yugen-ai/canso-helm-charts/blob/a912ebd652a4d2869738c3a166a77c45e6659f6f/canso-data-plane/canso-aws-eks-superchart/templates/aws/spark-operator.yaml#L6
-  # https://github.com/Yugen-ai/canso-helm-charts/blob/a912ebd652a4d2869738c3a166a77c45e6659f6f/canso-data-plane/canso-aws-eks-superchart/templates/aws/spark-operator.yaml#L17
+  # Namespace - https://github.com/Yugen-ai/canso-helm-charts/blob/a912ebd652a4d2869738c3a166a77c45e6659f6f/canso-data-plane/canso-aws-eks-superchart/templates/aws/spark-operator.yaml#L6
+  # Namespace - https://github.com/Yugen-ai/canso-helm-charts/blob/a912ebd652a4d2869738c3a166a77c45e6659f6f/canso-data-plane/canso-aws-eks-superchart/templates/aws/spark-operator.yaml#L17
+  # SA from Spark Operator - https://github.com/kubeflow/spark-operator/blob/b8c901397c042dbaaa8ff5ab15d16181b4a325e7/charts/spark-operator-chart/templates/_helpers.tpl#L57-L66
 }
 
 tags = {

--- a/canso-dataplane-configs/irsa-roles/spark/auto.tfvars
+++ b/canso-dataplane-configs/irsa-roles/spark/auto.tfvars
@@ -30,7 +30,10 @@ role_name   = "canso-dataplane-spark-s3-irsa-role"
 name_prefix = "canso-dataplane-spark-s3-irsa-role"
 
 cluster_service_accounts = {
-  "canso-dataplane-cluster" = ["streaming-jobs:spark-operator-spark"]
+  "canso-dataplane-cluster" = ["spark-streaming-jobs:spark-operator-spark", "spark-streaming-ml-jobs:spark-operator-spark"]
+  # TODO - Question re `spark-operator-spark` - To be resolved before PR merge.
+  # https://github.com/Yugen-ai/canso-helm-charts/blob/a912ebd652a4d2869738c3a166a77c45e6659f6f/canso-data-plane/canso-aws-eks-superchart/templates/aws/spark-operator.yaml#L6
+  # https://github.com/Yugen-ai/canso-helm-charts/blob/a912ebd652a4d2869738c3a166a77c45e6659f6f/canso-data-plane/canso-aws-eks-superchart/templates/aws/spark-operator.yaml#L17
 }
 
 tags = {


### PR DESCRIPTION
Cluster name was incorrect in canso-agent in `cluster_service_accounts` variable. Also, updated the namespace for Spark jobs.

TODOs

- [ ] Clarify & resolve the SA name as mentioned in a comment
- [ ] Update default streaming jobs namespace in Gru/Stuart/Jerry, wherever application

cc @sandeep-yugen @ashishYugen 