### PR TITLE
[NOJIRA] Update irsa role for airflow serviceaccount

### DIFF
--- a/canso-dataplane-configs/irsa-roles/airflow/auto.tfvars
+++ b/canso-dataplane-configs/irsa-roles/airflow/auto.tfvars
@@ -34,6 +34,10 @@ name_prefix = "airflow-canso-dataplane-irsa-role"
 
 cluster_service_accounts = {
   "canso-dataplane-cluster" = ["airflow:airflow-sa", "canso-airflow-jobs:airflow-jobs-sa", "canso-airflow-jobs:default"]
+  # Namespace airflow - https://github.com/Yugen-ai/canso-helm-charts/blob/a912ebd652a4d2869738c3a166a77c45e6659f6f/canso-data-plane/canso-aws-eks-superchart/values.yaml#L427
+  # Namespace canso-airflow-jobs - https://github.com/Yugen-ai/canso-helm-charts/blob/a912ebd652a4d2869738c3a166a77c45e6659f6f/canso-data-plane/canso-aws-eks-superchart/values.yaml#L306
+  # SA from Airflow - https://github.com/Yugen-ai/canso-helm-charts/blob/a912ebd652a4d2869738c3a166a77c45e6659f6f/canso-data-plane/canso-aws-eks-superchart/values.yaml#L312
+  # SA from canso-airflow-jobs - https://github.com/Yugen-ai/canso-helm-charts/blob/a912ebd652a4d2869738c3a166a77c45e6659f6f/canso-data-plane/canso-aws-eks-superchart/templates/aws/canso-airflow-jobs.yaml#L45
 }
 
 tags = {

--- a/canso-dataplane-configs/irsa-roles/airflow/auto.tfvars
+++ b/canso-dataplane-configs/irsa-roles/airflow/auto.tfvars
@@ -33,7 +33,7 @@ role_name   = "airflow-canso-dataplane-irsa-role"
 name_prefix = "airflow-canso-dataplane-irsa-role"
 
 cluster_service_accounts = {
-  "canso-dataplane-cluster" = ["airflow:ml-agents-dataplane", "airflow-jobs:airflow-jobs-sa", "airflow-jobs:default"]
+  "canso-dataplane-cluster" = ["airflow:airflow-sa", "canso-airflow-jobs:airflow-jobs-sa", "canso-airflow-jobs:default"]
 }
 
 tags = {


### PR DESCRIPTION
### Description

Updating IRSA role to add trust-relationships for airflow servie account in `airlfow` and `canso-airflow-jobs` namespace.
This is in sync with the default values in `canso-helm-chart` aws superchart

### Testing

Tested in the dataplane prod cluster.