### PR TITLE
Add `AmazonSSMManagedInstanceCore` to EKS Node role to enable SSH via AWS Session Manager in EKS EC2 instances

### DIFF
--- a/modules/canso-eks/aws-k8s-data-plane-canso-eks.md
+++ b/modules/canso-eks/aws-k8s-data-plane-canso-eks.md
@@ -28,6 +28,7 @@ No modules.
 | [aws_iam_role_policy_attachment.nodes-AmazonEC2ContainerRegistryReadOnly](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.nodes-AmazonEKSWorkerNodePolicy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.nodes-AmazonEKS_CNI_Policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.nodes-AmazonSSMManagedInstanceCore](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_security_group.cluster_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [kubernetes_config_map_v1_data.aws-auth](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1_data) | resource |
 | [aws_eks_cluster_auth.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |

--- a/modules/canso-eks/main.tf
+++ b/modules/canso-eks/main.tf
@@ -121,6 +121,11 @@ resource "aws_iam_role_policy_attachment" "nodes-AmazonEC2ContainerRegistryReadO
   role       = aws_iam_role.nodes.name
 }
 
+resource "aws_iam_role_policy_attachment" "nodes-AmazonSSMManagedInstanceCore" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  role       = aws_iam_role.nodes.name
+}
+
 ############################### 
 ## EKS Node Group
 ###############################
@@ -149,6 +154,7 @@ resource "aws_eks_node_group" "general" {
     aws_iam_role_policy_attachment.nodes-AmazonEKSWorkerNodePolicy,
     aws_iam_role_policy_attachment.nodes-AmazonEKS_CNI_Policy,
     aws_iam_role_policy_attachment.nodes-AmazonEC2ContainerRegistryReadOnly,
+    aws_iam_role_policy_attachment.nodes-AmazonSSMManagedInstanceCore,
     aws_eks_cluster.demo
   ]
 }


### PR DESCRIPTION
In line with SOC 2 Type Improvements (see https://github.com/Yugen-ai/access-management-hub/pull/30), we want to disable having to

1. Maintain, manage and rotate SSH keys.
2. Have permissive outbound rules in security groups such as `0.0.0.0/0`

To address the above, we attach the [`AmazonSSMManagedInstanceCore`](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonSSMManagedInstanceCore.html) policy to all EKS nodes, so that the SSM agent is present in all EC2 instances in the EKS cluster. 

Users have full flexibility to define their IAM groups & permissions/permission sets accordingly so that only those with valid IAM permissions can SSH into the nodes. 


### References

- [EKS Tales - Episode 9: Setting up SSM Access for AWS EKS Nodes](https://www.youtube.com/watch?v=8Nd-yZgYklk)