### PR TITLE
[HOTFIX] Remove Yugen from role name suffix

### DIFF
--- a/canso-dataplane-configs/irsa-roles/canso-agent/auto.tfvars
+++ b/canso-dataplane-configs/irsa-roles/canso-agent/auto.tfvars
@@ -9,7 +9,7 @@ iam_policy_policy = <<EOF
             "Action": [
                 "sts:AssumeRole"
             ],
-            "Resource": "arn:aws:iam::<control-plane-account-id>:role/CrossAccountSQSAccessRole"
+            "Resource": "arn:aws:iam::<control-plane-account-id>:role/CansoCrossAccountSQSAccessRole"
         }
     ]
 }

--- a/canso-dataplane-configs/irsa-roles/canso-agent/auto.tfvars
+++ b/canso-dataplane-configs/irsa-roles/canso-agent/auto.tfvars
@@ -9,7 +9,7 @@ iam_policy_policy = <<EOF
             "Action": [
                 "sts:AssumeRole"
             ],
-            "Resource": "arn:aws:iam::<control-plane-account-id>:role/CrossAccountSQSAccessRoleYugen"
+            "Resource": "arn:aws:iam::<control-plane-account-id>:role/CrossAccountSQSAccessRole"
         }
     ]
 }


### PR DESCRIPTION
Description
The Canso agent requires the CrossAccountSQSAccess role to access the control plane SQS for data reading. Therefore, removed `Yugen` from the suffix of the role name and added `Canso` as a prefix.

