### PR TITLE
Adding depends_on in RDS module to avoid dependency error

### DIFF
--- a/modules/canso-rds/rds-instance.tf
+++ b/modules/canso-rds/rds-instance.tf
@@ -28,4 +28,6 @@ resource "aws_db_instance" "this" {
   skip_final_snapshot     = true
   apply_immediately       = true
   backup_retention_period = 0
+
+  depends_on      = [aws_db_subnet_group.default]
 }

--- a/modules/canso-rds/rds-instance.tf
+++ b/modules/canso-rds/rds-instance.tf
@@ -29,5 +29,5 @@ resource "aws_db_instance" "this" {
   apply_immediately       = true
   backup_retention_period = 0
 
-  depends_on      = [aws_db_subnet_group.default]
+  depends_on = [aws_db_subnet_group.default]
 }


### PR DESCRIPTION
### Description

While applying canso-rds module, observed below error:
```
Error: creating RDS DB Instance (canso-dplane-v1-airflow-ap-rds): operation error RDS: CreateDBInstance, https response error StatusCode: 404, RequestID: b18be863-eb23-4476-8729-62da0de77e58, DBSubnetGroupNotFoundFault: DBSubnetGroup 'canso-dplane-v1-rds-subnet-group' not found.

  with aws_db_instance.this,
  on rds-instance.tf line 1, in resource "aws_db_instance" "this":
   1: resource "aws_db_instance" "this" {
```
Adding `depends_on` to prevent this error

### Testing

Tested while applying rds module for `canso-dplane-v1` cluster

output: RDS instance created with updated module:
<img width="1204" alt="image" src="https://github.com/user-attachments/assets/fca28f0c-d8d6-424d-9d43-7f7eb015d467">
