### PR TITLE
[NOJIRA] Updating EKS module with refined security group configuration

### DIFF
--- a/canso-dataplane-configs/eks/auto.tfvars
+++ b/canso-dataplane-configs/eks/auto.tfvars
@@ -16,7 +16,7 @@ vpc_id          = "vpc-xxxxxxxxxxxxxxxxx"
 cluster_sg_tags = {
   Name = "canso-dataplane-cluster-cluster-sg"
 }
-k8s_version = "1.29"
+k8s_version           = "1.29"
 alb_security_group_id = "sg-xxxxxxxxxxxxxxxxxx"
 
 ####################### node group general #################

--- a/canso-dataplane-configs/eks/auto.tfvars
+++ b/canso-dataplane-configs/eks/auto.tfvars
@@ -17,6 +17,7 @@ cluster_sg_tags = {
   Name = "canso-dataplane-cluster-cluster-sg"
 }
 k8s_version = "1.29"
+alb_security_group_id = "sg-xxxxxxxxxxxxxxxxxx"
 
 ####################### node group general #################
 eks_node_role_name         = "canso-dataplane-cluster-node-role"

--- a/modules/canso-eks/aws-k8s-data-plane-canso-eks.md
+++ b/modules/canso-eks/aws-k8s-data-plane-canso-eks.md
@@ -38,6 +38,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_alb_security_group_id"></a> [alb\_security\_group\_id](#input\_alb\_security\_group\_id) | AlB Security Group ID for EKS ingress security | `string` | n/a | yes |
 | <a name="input_ami_type"></a> [ami\_type](#input\_ami\_type) | ami\_type | `string` | n/a | yes |
 | <a name="input_capacity_type"></a> [capacity\_type](#input\_capacity\_type) | capacity\_type | `string` | n/a | yes |
 | <a name="input_cluster_role_name"></a> [cluster\_role\_name](#input\_cluster\_role\_name) | cluster\_role\_name | `string` | n/a | yes |

--- a/modules/canso-eks/main.tf
+++ b/modules/canso-eks/main.tf
@@ -67,10 +67,10 @@ resource "aws_security_group" "cluster_sg" {
   tags        = var.cluster_sg_tags
 
   ingress {
-    from_port        = 0
-    to_port          = 0
-    protocol         = "-1"
-    security_groups  = [var.alb_security_group_id]
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    security_groups = [var.alb_security_group_id]
   }
 
   egress {

--- a/modules/canso-eks/main.tf
+++ b/modules/canso-eks/main.tf
@@ -70,8 +70,7 @@ resource "aws_security_group" "cluster_sg" {
     from_port        = 0
     to_port          = 0
     protocol         = "-1"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
+    security_groups  = [var.alb_security_group_id]
   }
 
   egress {

--- a/modules/canso-eks/variables.tf
+++ b/modules/canso-eks/variables.tf
@@ -138,3 +138,8 @@ variable "map_role_string_admin" {
   type        = string
   #default = ""
 }
+
+variable "alb_security_group_id" {
+  description = "AlB Security Group ID for EKS ingress security"
+  type        = string
+}


### PR DESCRIPTION

### Description

This PR updates the EKS module to enhance the security posture of the EKS cluster by refining the security group configuration. 
The main change is to restrict ingress traffic to only allow connections from the associated Application Load Balancer (ALB) security group, providing more precise control over network access to the EKS cluster.
 
- Modified the aws_security_group resource in the EKS module
- Removed broad ingress rule allowing all traffic (0.0.0.0/0)
- Added specific ingress rule to allow traffic only from the ALB security group


### Testing

**cmd**:

`terraform plan --var-file=../../cplane-demo-sg/eks/auto.tfvars`

**output**:

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the
following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # aws_security_group.cluster_sg will be updated in-place
  ~ resource "aws_security_group" "cluster_sg" {
        id                     = "sg-xxxxxxxxxxxxxx"
      ~ ingress                = [
          - {
              - cidr_blocks      = [
                  - "0.0.0.0/0",
                ]
              - description      = ""
              - from_port        = 0
              - ipv6_cidr_blocks = [
                  - "::/0",
                ]
              - prefix_list_ids  = []
              - protocol         = "-1"
              - security_groups  = []
              - self             = false
              - to_port          = 0
            },
          + {
              + cidr_blocks      = []
              + description      = ""
              + from_port        = 0
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "-1"
              + security_groups  = [
                  + "sg-xxxxxxxxxxxxxx",
                ]
              + self             = false
              + to_port          = 0
            },
        ]
        name                   = "canso-demo-sg"
        tags                   = {
            "Name" = "canso-demo-sg"
        }
        # (7 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

```


### Deployment

1. Merge the PR after approvals

### Rollback

1. Standard PR Revert
