### PR TITLE
[NOJIRA] Updating EKS module ingress and additional rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,35 @@ vpc_id = "vpc-xxxxxxxxxxxxxxxxx"
 > If you change the cluster name, ensure you update the same in the rest of the configs, especially the IRSA roles.
 > For e.g Each IRSA role has a `cluster_service_accounts` variable that uses the cluster name.
 
+Any ingress rules(forthe VPC security group) or additional rules(for the EKS security group) can be added as follows:
+```
+additional_security_group_rules = [
+  {
+    type                     = "ingress"
+    from_port                = 30000
+    to_port                  = 32767
+    protocol                 = "tcp"
+    source_security_group_id = "sg-xxxxxxxxxxxxxxxxxxxxx"  
+    description              = "Allow security group to access the EKS security group"
+  }
+]
+
+vpc_ingress_rules = [
+  {
+    description     = "Allow HTTP from anywhere"
+    from_port       = 80
+    to_port         = 80
+    protocol        = "tcp"
+    cidr_blocks     = ["0.0.0.0/0"]
+    security_groups = []
+  }
+]
+```
+
+> [!CAUTION]
+> Removing any previous ingress rules applied will not be detected by terraform. This is due to a known issue -  https://github.com/hashicorp/terraform-provider-aws/issues/4399 This will be fixed in a later release. Users can remove the ingress rules from the security group manually if needed.
+
+
 ---
 
 ### Step 3 - AWS IRSA Roles

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ vpc_id = "vpc-xxxxxxxxxxxxxxxxx"
 > If you change the cluster name, ensure you update the same in the rest of the configs, especially the IRSA roles.
 > For e.g Each IRSA role has a `cluster_service_accounts` variable that uses the cluster name.
 
-Any ingress rules(forthe VPC security group) or additional rules(for the EKS security group) can be added as follows:
+Any ingress rules(for the VPC security group) or additional rules(for the EKS security group) can be added as follows:
 ```
 additional_security_group_rules = [
   {

--- a/modules/canso-eks/aws-k8s-data-plane-canso-eks.md
+++ b/modules/canso-eks/aws-k8s-data-plane-canso-eks.md
@@ -38,7 +38,6 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_alb_security_group_id"></a> [alb\_security\_group\_id](#input\_alb\_security\_group\_id) | AlB Security Group ID for EKS ingress security | `string` | n/a | yes |
 | <a name="input_ami_type"></a> [ami\_type](#input\_ami\_type) | ami\_type | `string` | n/a | yes |
 | <a name="input_capacity_type"></a> [capacity\_type](#input\_capacity\_type) | capacity\_type | `string` | n/a | yes |
 | <a name="input_cluster_role_name"></a> [cluster\_role\_name](#input\_cluster\_role\_name) | cluster\_role\_name | `string` | n/a | yes |

--- a/modules/canso-eks/aws-k8s-data-plane-canso-eks.md
+++ b/modules/canso-eks/aws-k8s-data-plane-canso-eks.md
@@ -30,6 +30,7 @@ No modules.
 | [aws_iam_role_policy_attachment.nodes-AmazonEKS_CNI_Policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.nodes-AmazonSSMManagedInstanceCore](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_security_group.cluster_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.additional_rules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [kubernetes_config_map_v1_data.aws-auth](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1_data) | resource |
 | [aws_eks_cluster_auth.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
 | [tls_certificate.eks](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate) | data source |
@@ -38,6 +39,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_additional_security_group_rules"></a> [additional\_security\_group\_rules](#input\_additional\_security\_group\_rules) | List of additional security group rules to create for other security groups | <pre>list(object({<br/>    type              = string<br/>    from_port         = number<br/>    to_port           = number<br/>    protocol          = string<br/>    source_security_group_id = string<br/>    description       = optional(string)<br/>  }))</pre> | `[]` | no |
 | <a name="input_ami_type"></a> [ami\_type](#input\_ami\_type) | ami\_type | `string` | n/a | yes |
 | <a name="input_capacity_type"></a> [capacity\_type](#input\_capacity\_type) | capacity\_type | `string` | n/a | yes |
 | <a name="input_cluster_role_name"></a> [cluster\_role\_name](#input\_cluster\_role\_name) | cluster\_role\_name | `string` | n/a | yes |
@@ -66,6 +68,7 @@ No modules.
 | <a name="input_region"></a> [region](#input\_region) | region name | `string` | n/a | yes |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | subnet\_ids | `list(string)` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | vpc\_id | `string` | n/a | yes |
+| <a name="input_vpc_ingress_rules"></a> [vpc\_ingress\_rules](#input\_vpc\_ingress\_rules) | List of ingress rules | <pre>list(object({<br/>    description     = string<br/>    from_port       = number<br/>    to_port         = number<br/>    protocol        = string<br/>    cidr_blocks     = list(string)<br/>    security_groups = list(string)<br/>  }))</pre> | `[]` | no |
 
 ## Outputs
 

--- a/modules/canso-eks/aws-k8s-data-plane-canso-eks.md
+++ b/modules/canso-eks/aws-k8s-data-plane-canso-eks.md
@@ -39,7 +39,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_additional_security_group_rules"></a> [additional\_security\_group\_rules](#input\_additional\_security\_group\_rules) | List of additional security group rules to create for other security groups | <pre>list(object({<br/>    type              = string<br/>    from_port         = number<br/>    to_port           = number<br/>    protocol          = string<br/>    source_security_group_id = string<br/>    description       = optional(string)<br/>  }))</pre> | `[]` | no |
+| <a name="input_additional_security_group_rules"></a> [additional\_security\_group\_rules](#input\_additional\_security\_group\_rules) | List of additional security group rules to create for other security groups | <pre>list(object({<br/>    type                     = string<br/>    from_port                = number<br/>    to_port                  = number<br/>    protocol                 = string<br/>    source_security_group_id = string<br/>    description              = optional(string)<br/>  }))</pre> | `[]` | no |
 | <a name="input_ami_type"></a> [ami\_type](#input\_ami\_type) | ami\_type | `string` | n/a | yes |
 | <a name="input_capacity_type"></a> [capacity\_type](#input\_capacity\_type) | capacity\_type | `string` | n/a | yes |
 | <a name="input_cluster_role_name"></a> [cluster\_role\_name](#input\_cluster\_role\_name) | cluster\_role\_name | `string` | n/a | yes |

--- a/modules/canso-eks/main.tf
+++ b/modules/canso-eks/main.tf
@@ -89,8 +89,8 @@ resource "aws_security_group" "cluster_sg" {
 }
 
 resource "aws_security_group_rule" "additional_rules" {
-  depends_on = [ aws_eks_cluster.demo ]
-  count = length(var.additional_security_group_rules)
+  depends_on = [aws_eks_cluster.demo]
+  count      = length(var.additional_security_group_rules)
 
   type                     = var.additional_security_group_rules[count.index].type
   from_port                = var.additional_security_group_rules[count.index].from_port

--- a/modules/canso-eks/main.tf
+++ b/modules/canso-eks/main.tf
@@ -46,6 +46,7 @@ resource "aws_eks_cluster" "demo" {
   ]
   tags = var.eks_cluster_tags
 
+
   vpc_config {
 
     endpoint_private_access = var.endpoint_private_access
@@ -66,11 +67,16 @@ resource "aws_security_group" "cluster_sg" {
   vpc_id      = var.vpc_id
   tags        = var.cluster_sg_tags
 
-  ingress {
-    from_port       = 0
-    to_port         = 0
-    protocol        = "-1"
-    security_groups = [var.alb_security_group_id]
+  dynamic "ingress" {
+    for_each = var.vpc_ingress_rules
+    content {
+      description     = ingress.value.description
+      from_port       = ingress.value.from_port
+      to_port         = ingress.value.to_port
+      protocol        = ingress.value.protocol
+      cidr_blocks     = ingress.value.cidr_blocks
+      security_groups = ingress.value.security_groups
+    }
   }
 
   egress {
@@ -80,6 +86,19 @@ resource "aws_security_group" "cluster_sg" {
     cidr_blocks      = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
   }
+}
+
+resource "aws_security_group_rule" "additional_rules" {
+  depends_on = [ aws_eks_cluster.demo ]
+  count = length(var.additional_security_group_rules)
+
+  type                     = var.additional_security_group_rules[count.index].type
+  from_port                = var.additional_security_group_rules[count.index].from_port
+  to_port                  = var.additional_security_group_rules[count.index].to_port
+  protocol                 = var.additional_security_group_rules[count.index].protocol
+  security_group_id        = aws_eks_cluster.demo.vpc_config[0].cluster_security_group_id
+  source_security_group_id = var.additional_security_group_rules[count.index].source_security_group_id
+  description              = lookup(var.additional_security_group_rules[count.index], "description", null)
 }
 
 ############################### 

--- a/modules/canso-eks/variables.tf
+++ b/modules/canso-eks/variables.tf
@@ -158,13 +158,13 @@ variable "vpc_ingress_rules" {
 variable "additional_security_group_rules" {
   description = "List of additional security group rules to create for other security groups"
   type = list(object({
-    type              = string
-    from_port         = number
-    to_port           = number
-    protocol          = string
+    type                     = string
+    from_port                = number
+    to_port                  = number
+    protocol                 = string
     source_security_group_id = string
-    description       = optional(string)
+    description              = optional(string)
   }))
-  default =[]
+  default = []
 }
 

--- a/modules/canso-eks/variables.tf
+++ b/modules/canso-eks/variables.tf
@@ -139,7 +139,32 @@ variable "map_role_string_admin" {
   #default = ""
 }
 
-variable "alb_security_group_id" {
-  description = "AlB Security Group ID for EKS ingress security"
-  type        = string
+#### Security group rules
+
+variable "vpc_ingress_rules" {
+  description = "List of ingress rules"
+  type = list(object({
+    description     = string
+    from_port       = number
+    to_port         = number
+    protocol        = string
+    cidr_blocks     = list(string)
+    security_groups = list(string)
+  }))
+  default = []
 }
+
+
+variable "additional_security_group_rules" {
+  description = "List of additional security group rules to create for other security groups"
+  type = list(object({
+    type              = string
+    from_port         = number
+    to_port           = number
+    protocol          = string
+    source_security_group_id = string
+    description       = optional(string)
+  }))
+  default =[]
+}
+


### PR DESCRIPTION
### Description

This PR

1. Updates the `aws_security_group` to add ingress rules dynamically from the variables instead of the hardcoded all inbound access policy
2. Adds the option to add a list of additional policies to the security group created automatically by the `aws_eks` resource. see- [cluster_security_group_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_cluster#:~:text=cluster_security_group_id)

Solves the issue - #24 

> [!CAUTION]
> Removing any previous ingress rules applied will not be detected by terraform. This is due to a known issue -  https://github.com/hashicorp/terraform-provider-aws/issues/4399 This will be fixed in a later release. Users can remove the ingress rules from the security group manually if needed.

### Testing

**cmd**:
`terraform plan --var-file=../../cplane-stage-v1-configs-sg/eks/auto.tfvars`

**output**:
```
Terraform will perform the following actions:

  # aws_security_group_rule.additional_rules[0] will be created
  + resource "aws_security_group_rule" "additional_rules" {
      + description              = "Allow ALB security group to access the EKS security group"
      + from_port                = 30000
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = "sg-0d8xxxxx73b"
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = "sg-0xxxxxxxxf4ec"
      + to_port                  = 32767
      + type                     = "ingress"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```
### Deployment

1. Run `terraform apply` after approvals
2. Verify manually that the additional security rules are added to the eks security group.
3. Merge the PR.

### Rollback

1. Revert the PR.
2. Run `terraform apply on the reverted PR.`